### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/LumiGeek/keywords.txt
+++ b/LumiGeek/keywords.txt
@@ -10,17 +10,17 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
+begin	KEYWORD2
 
-eeprom KEYWORD2
-dac KEYWORD2
-accelerometer KEYWORD2
-temperature KEYWORD2
+eeprom	KEYWORD2
+dac	KEYWORD2
+accelerometer	KEYWORD2
+temperature	KEYWORD2
 
-stripBankA KEYWORD2
-stripBankB KEYWORD2
-addressable KEYWORD2
-dmx KEYWORD2
+stripBankA	KEYWORD2
+stripBankB	KEYWORD2
+addressable	KEYWORD2
+dmx	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords